### PR TITLE
3 small issues in the drupal 6 ck module

### DIFF
--- a/media_mediamosa.module
+++ b/media_mediamosa.module
@@ -264,11 +264,10 @@ function media_mediamosa_cron() {
     return FALSE;
   }
 
-
+  watchdog('cron-sync', 'number of assets: ' . count($assets));
   // Check the response.
 
   foreach ($assets as $key => $asset) {
-
     if ($asset['is_empty_asset'] == 'TRUE') {
       watchdog('Mediamosa CK', "Ignore empty asset @asset_id.", array('@asset_id' => $asset['asset_id']), WATCHDOG_DEBUG);
       continue;
@@ -278,7 +277,12 @@ function media_mediamosa_cron() {
     $create = FALSE;
 
     // We store the nid in the group id value.
-    $nid = $asset['group_id'];
+    // $nid = $asset['group_id']; // unwanted, we store the asset_id in the ega instead, disable for old behaviour.
+
+    // we look for asset_id in mediafields...
+    $asset_id = $asset['asset_id'];
+    $nid = db_result(db_query_range("SELECT nid FROM {content_type_mediamosa_videocontent} WHERE field_mediamosa_videofile_embed = '$asset_id' ", 0, 1));
+
     if (!$nid) {
       // New asset without node.
       $create = TRUE;
@@ -301,7 +305,7 @@ function media_mediamosa_cron() {
       // Create a new node.
       $node = new stdClass();
       // Temporary title.
-      $node->title = t('node has no title');
+      @$node->title = $asset['dublin_core']['title']; // t('node has no title');
       $node->type = $type;
       $node->status = 1;
       $node->uid = 1;
@@ -319,10 +323,10 @@ function media_mediamosa_cron() {
       }
 
       // Set the nid in $assets array.
-      //$assets[$key]['group_id'] = $nid;
-      $asset['group_id'] = $nid;
-      _media_mediamosa_reference_id_update($asset['asset_id'], $nid, $asset['owner_id']);
-
+      // $assets[$key]['group_id'] = $nid;
+      // $asset['group_id'] = $nid;
+      // _media_mediamosa_reference_id_update($asset['asset_id'], $nid, $asset['owner_id']);
+      // remark: old behaviour; we now use the asset_id from the client app.
     }
 
     // Check mostly for the case that node ID in our system occupied for other content type.

--- a/media_mediamosa_helpers.inc
+++ b/media_mediamosa_helpers.inc
@@ -1404,7 +1404,7 @@ function _media_mediamosa_generate_video_output($mediafile_id, $node_type, $auto
         );
       }
       else {
-        $output .= t('Video in progress! Comming soon!');
+        $output .= t('Video transcode in progress, please wait.');
       }
     }
   }
@@ -1440,7 +1440,7 @@ function _media_mediamosa_generate_video_output($mediafile_id, $node_type, $auto
         $output .= theme('job_progress_bar', $mediafile_id, $node_type, 100 * $job_transcode['progress'], t('The mediafile is under transcoding. Please, wait.'));
       }
       else {
-        $output .= t('Video in progress! Comming soon!');
+        $output .= t('Video transcode in progress, please wait.');
       }
     }
     elseif ($response->xml->header->request_result_id == ERRORCODE_NOT_AUTHORIZED) {

--- a/providers/emvideo/mediamosa.inc
+++ b/providers/emvideo/mediamosa.inc
@@ -164,38 +164,8 @@ function emvideo_mediamosa_thumbnail($field, $item, $formatter, $node, $width, $
   }
 
   $asset_id = $item['value'];
-  $mediafile = _media_mediamosa_get_mediafile_original($asset_id);
-  $mediafile_id = $mediafile['mediafile_id'];
-
-  $thumbnail = drupal_get_path('module', 'media_mediamosa') . '/images/still.png';
-
-  // Get the basic data and the still.
-  $mediafile = _media_mediamosa_mediafile_get($mediafile_id);
-  if (!empty($mediafile['still'])) {
-
-    // Fix the problem with 1 or 2+ items in array.
-    $tmp = isset($mediafile['still'][0]) ? $mediafile['still'] : array(0 => $mediafile['still']);
-    unset($mediafile['still']);
-    $mediafile['still'] = $tmp;
-
-    $stills = $mediafile['still'];
-    foreach ($stills as $still) {
-      if ((string)$still['still_default'] == 'TRUE') {
-        // Get the default.
-        $thumbnail = (string) $still['still_ticket'];
-      }
-      elseif (!$thumbnail) {
-        // If no thumbnail yet, then get the first one.
-        $thumbnail = (string) $still['still_ticket'];
-      }
-    }
-  }
-
-  // Get the stills.
-  if (!$thumbnail) {
-    $asset = _media_mediamosa_asset_get($assset_id);
-    $thumbnail = (string) $asset['vpx_still_url'];
-  }
+  $asset = _media_mediamosa_asset_get($asset_id);
+  $thumbnail = (string) $asset['vpx_still_url'];
 
   return $thumbnail;
 }


### PR DESCRIPTION
A request for a still resulted in 2 restcalls, now limited to 1. (should go down to 0; with either storing the still_url or using imagecache)

Node Title now defaults to dublin core title. (instead of "node has no title")

The link between frontend nodes and backend assets is now stored in the frontend (emvideo), instead of the group_id which resulted in all sorts of strange behaviour. It should not break current implementations, as asset_id is already stored.
