### PR TITLE
Update media_mediamosa.stream.wrapper.class.inc

### DIFF
--- a/modules/media_mediamosa/media_mediamosa.stream.wrapper.class.inc
+++ b/modules/media_mediamosa/media_mediamosa.stream.wrapper.class.inc
@@ -77,7 +77,8 @@ class MediaMosaStreamWrapper extends MediaReadOnlyStreamWrapper {
    *   Either array filled or FALSE.
    */
   public static function mediamosa_parse_url_from_fid($fid) {
-    $media = reset(media_multi_load($fid));
+    $media = media_multi_load($fid);
+    reset($media);
     if (!$media || !isset($media->uri)) {
       return FALSE;
     }


### PR DESCRIPTION
The oneliner was generating warnings:

Strict warning: Only variables should be passed by reference in MediaMosaStreamWrapper::mediamosa_parse_url_from_fid() (regel 80 van C:\wamp\www\ingebeeld\www\sites\all\modules\contrib\mediamosa-ck\modules\media_mediamosa\media_mediamosa.stream.wrapper.class.inc).
