### PR TITLE
fix for deprecated media_multi_load function in media module

### DIFF
--- a/modules/media_mediamosa/media_mediamosa.class.inc
+++ b/modules/media_mediamosa/media_mediamosa.class.inc
@@ -115,7 +115,7 @@ class MediaMediaMosa {
 
     // To distinct data in Drupal and in Mediamosa we use drupal_ prefix for
     // the Drupal side variables.
-    $drupal_multiple_media = media_multi_load("{$media_id}");
+    $drupal_multiple_media = media_mediamosa_multi_load("{$media_id}");
     $drupal_media = $drupal_multiple_media[$media_id];
 
     $drupal_uri = mediamosa_ck::fileuri2parts($drupal_media->uri);

--- a/modules/media_mediamosa/media_mediamosa.inc
+++ b/modules/media_mediamosa/media_mediamosa.inc
@@ -137,8 +137,8 @@ function _media_mediamosa_file_type_check($fid) {
   }
 
   // Again, we don't have media_load function, so we have to use
-  // media_multi_load() and then reset array.
-  $multi_media = media_multi_load($fid);
+  // media_mediamosa_multi_load() and then reset array.
+  $multi_media = media_mediamosa_multi_load($fid);
 
   if ($multi_media) {
     foreach ($multi_media as $media) {

--- a/modules/media_mediamosa/media_mediamosa.module
+++ b/modules/media_mediamosa/media_mediamosa.module
@@ -442,7 +442,7 @@ function media_mediamosa_mediamosa_ck_configuration_collect() {
 function media_mediamosa_media_edit_submit($form, &$form_state) {
 
   // Fix for missing media_load() function.
-  $multi_media = media_multi_load($form_state['values']['fid']);
+  $multi_media = media_mediamosa_multi_load($form_state['values']['fid']);
 
   foreach ($multi_media as $media) {
     // Now we have Mediamosa URI in $media->uri .
@@ -695,4 +695,11 @@ function _batch_process_mediamosa_to_drupal($limit, &$context) {
 function media_mediamosa_entity_info_alter(&$entity_info) {
   // FIXME: Needs review.
   //$entity_info['node']['field cache'] = FALSE;
+}
+
+/**
+ * Helper function for the deprecated media_multi_load function.
+ */
+function media_mediamosa_multi_load($fids) {
+  return file_load_multiple(explode(' ', $fids));
 }

--- a/modules/media_mediamosa/media_mediamosa.stream.wrapper.class.inc
+++ b/modules/media_mediamosa/media_mediamosa.stream.wrapper.class.inc
@@ -83,7 +83,7 @@ class MediaMosaStreamWrapper extends MediaReadOnlyStreamWrapper {
    *   Either array filled or FALSE.
    */
   public static function mediamosa_parse_url_from_fid($fid) {
-    $media = media_multi_load($fid);
+    $media = media_mediamosa_multi_load($fid);
     $media = reset($media);
     if (!$media || !isset($media->uri)) {
       return FALSE;

--- a/modules/mediamosa_ck_transcode/mediamosa_ck_transcode.module
+++ b/modules/mediamosa_ck_transcode/mediamosa_ck_transcode.module
@@ -217,7 +217,7 @@ function _mediamosa_ck_transcode_list_form($form, &$form_state) {
   );
 
   $media_data = MediaMosaStreamWrapper::mediamosa_parse_url_from_fid($fid);
-  $multi_media = media_multi_load($fid);
+  $multi_media = media_mediamosa_multi_load($fid);
   if ($multi_media) {
     foreach ($multi_media as $media) {
       try {


### PR DESCRIPTION
The `media_multi_load` function was removed in the current media 7.x-2.x-dev version resulting in errors during the cron-runs.
