### PR TITLE
Add hook to allow modules to add extra metadata fields

### DIFF
--- a/mediamosa_ck.api.php
+++ b/mediamosa_ck.api.php
@@ -48,5 +48,11 @@ function hook_mediamosa_ck_configuration_collect_submit($form, &$form_state) {
 }
 
 /**
+ * Allows modules to define additional metadata fields.
+ */
+function hook_mediamosa_ck_metadata_fields($metadata_fields) {
+}
+
+/**
  * @} End of "addtogroup hooks".
  */

--- a/mediamosa_ck.class.inc
+++ b/mediamosa_ck.class.inc
@@ -592,7 +592,7 @@ class mediamosa_ck extends mediamosa_sdk {
       ),
     );
 
-    $additional_fields = module_invoke_all('mediamosa_metadata_fields', $metadata_fields);
+    $additional_fields = module_invoke_all('mediamosa_ck_metadata_fields', $metadata_fields);
     $metadata_fields += $additional_fields;
 
     return $metadata_fields;


### PR DESCRIPTION
It would obviously be better if the MediaMosa backend have a REST-call
to get all the metadata fields for the current app, but until that is
implemented this hook can be used by modules to add additional fields
which are defined in the backend.
