### PR TITLE
escape filter values to produce valid CQL

### DIFF
--- a/modules/mediamosa_ck_views/handlers/mediamosa_ck_views_filter.class.inc
+++ b/modules/mediamosa_ck_views/handlers/mediamosa_ck_views_filter.class.inc
@@ -54,11 +54,11 @@ class mediamosa_ck_views_filter extends views_handler_filter {
       foreach ($values as $value) {
         if (is_array($value)) {
           foreach ($value as $value_child) {
-            $cql_or[] = $this->field . '="' . $value_child . '"';
+            $cql_or[] = $this->field . '="' . mediamosa_sdk::escape_cql($value_child) . '"';
           }
         }
         else {
-          $cql_or[] = $this->field . '="' . $value . '"';
+          $cql_or[] = $this->field . '="' . mediamosa_sdk::escape_cql($value) . '"';
         }
       }
 


### PR DESCRIPTION
When the field is exposed to the end user a quote needs to be properly
escaped to produce valid CQL
