### PR TITLE
views: support multiple values for metadata

### DIFF
--- a/mediamosa_ck.class.inc
+++ b/mediamosa_ck.class.inc
@@ -842,6 +842,14 @@ class mediamosa_ck extends mediamosa_sdk {
       return self::get_asset_value($asset->items->item, $field, $default);
     }
 
+    if (is_array($asset->{$field})) {
+      if (count($asset->{$field}) > 0) {
+        return $asset->{$field}[0];
+      }
+      // the field is an array but does not contain any elements, return default
+      return $default;
+    }
+
     // Might be object that already has it set as [set].[name]
     if ((string) $asset->{$field} !== '') {
       return (string) $asset->{$field};

--- a/modules/mediamosa_ck_views/handlers/mediamosa_ck_views_field_text_metadata.class.inc
+++ b/modules/mediamosa_ck_views/handlers/mediamosa_ck_views_field_text_metadata.class.inc
@@ -10,8 +10,6 @@ class mediamosa_ck_views_field_text_metadata extends views_handler_field {
     $options = parent::option_definition();
 
     $options['metadata_theme'] = array('default' => 'mediamosa_ck_view_theme_asset_metadata');
-    $options['metadata_implode'] = array('default' => 0);
-    $options['metadata_implode_string'] = array('default' => NULL);
 
     return $options;
   }
@@ -27,22 +25,6 @@ class mediamosa_ck_views_field_text_metadata extends views_handler_field {
       '#type' => 'textfield',
       '#default_value' => $this->options['metadata_theme'],
     );
-
-    $form['metadata_implode'] = array(
-      '#type' => 'checkbox', 
-      '#title' => t('Join multiple values'),
-      '#description' => t('When the field has multiple values, join it into one string.'),
-      '#default_value' => $this->options['metadata_implode'],
-    );
-
-    $form['metadata_implode_string'] = array(
-      '#type' => 'textfield', 
-      '#title' => t('Join string'), 
-      '#description' => t('When the field contains multiple values and should be joined,
-                           this string will be used. You can use <code>\n</code> for a newline.'),
-      '#default_value' => $this->options['metadata_implode_string'],
-      '#size' => 10,
-    );
   }
 
   /**
@@ -57,12 +39,6 @@ class mediamosa_ck_views_field_text_metadata extends views_handler_field {
 
     // Get the data.
     $technical_metadata = parent::get_value($values, $field);
-
-    foreach ($technical_metadata as $key => $data) {
-      if (is_array($data) && $this->shouldJoinValues()) {
-        $technical_metadata[$key] = implode($this->getJoinString(), $data);
-      }
-    }
 
     return theme($this->options['metadata_theme'], array('metadata' => $technical_metadata));
   }
@@ -89,14 +65,5 @@ class mediamosa_ck_views_field_text_metadata extends views_handler_field {
     if (!empty($this->additional_fields)) {
       $this->add_additional_fields($this->additional_fields);
     }
-  }
-
-  protected function shouldJoinValues() {
-    return isset($this->options['metadata_implode']) ? $this->options['metadata_implode'] : FALSE;
-  }
-
-  protected function getJoinString() {
-    $str = isset($this->options['metadata_implode_string']) ? $this->options['metadata_implode_string'] : '';
-    return str_replace('\n', "\n", $str);
   }
 }

--- a/modules/mediamosa_ck_views/mediamosa_ck_views.theme.inc
+++ b/modules/mediamosa_ck_views/mediamosa_ck_views.theme.inc
@@ -116,6 +116,10 @@ function theme_mediamosa_ck_views_theme_asset_metadata($variables) {
   foreach ($variables['metadata'] as $name => $value) {
     $name = drupal_ucfirst(str_replace('_', ' ', $name));
 
+    if (is_array($value)) {
+      $value = implode("\n", $value);
+    }
+
     $rows[] = array('name' => $name, 'value' => (empty($value) ? ' ' : nl2br(check_plain($value))));
   }
 

--- a/modules/mediamosa_ck_views/plugins/mediamosa_ck_views_rest_asset_get.class.inc
+++ b/modules/mediamosa_ck_views/plugins/mediamosa_ck_views_rest_asset_get.class.inc
@@ -85,28 +85,10 @@ class mediamosa_ck_views_rest_asset_get extends mediamosa_ck_views_rest_asset {
         foreach ($item->xpath($metadata['xpath']) as $metadata_value) {
           foreach ($metadata_value as $name => $value) {
             // In variable.
-            if (empty($object->{$set . '.'. (string) $name})) {
-              // first time we see this item
-              $object->{$set . '.' . (string) $name} = (string) $value;
-            } else {
-              // item has multiple values, convert to array if necessary
-              if (!is_array($object->{$set . '.' . (string) $name})) {
-                $object->{$set . '.' . (string) $name} = array($object->{$set . '.' . (string) $name});
-              }
-              // and add the new value to the array
-              $object->{$set . '.' . (string) $name}[] = (string) $value;
-            }
+            $object->{$set . '.' . (string) $name}[] = (string) $value;
 
             // In set.
-            if (empty($object->{'metadata_' . $set}[(string) $name])) {
-              $object->{'metadata_' . $set}[(string) $name] = (string) $value;
-            } else {
-              // item has multiple values, convert to array if necessary
-              if (!is_array($object->{'metadata_' . $set}[(string) $name])) {
-                $object->{'metadata_' . $set}[(string) $name] = array($object->{'metadata_' . $set}[(string) $name]);
-              }
-              $object->{'metadata_' . $set}[(string) $name][] = (string) $value;
-            }
+            $object->{'metadata_' . $set}[(string) $name][] = (string) $value;
           }
         }
       }


### PR DESCRIPTION
For the moment only the last value is used in views. This patch add support for more values. It adds two options to the 'metadata blocks' fields in views. This allows the user to configure what should happen with the multiple values. Either the multiple values are kept as an array in order to let the theming function deal with it. Or the values are joinned into a single string using the specified join string.
I'm not entirely sure if similar logic should be added to other views handlers as well.
