### PR TITLE
Fixed variable height of player.

### DIFF
--- a/modules/mediamosa_ck_views/handlers/mediamosa_ck_views_field_player.class.inc
+++ b/modules/mediamosa_ck_views/handlers/mediamosa_ck_views_field_player.class.inc
@@ -124,12 +124,14 @@ class mediamosa_ck_views_field_player extends views_handler_field {
     // Response.
     $options['response'] = $this->options['response'];
 
-    // Both not empty.
-    if (!empty($this->options['player_width']) && !empty($this->options['player_height'])) {
+    // Width and/of height.
+    if (!empty($this->options['player_width'])) {
       $options['width'] = $this->options['player_width'];
-      $options['height'] = $this->options['player_height'];
-      $options['autostart'] = $this->options['player_autostart'] ? 'TRUE' : 'FALSE';
     }
+    if (!empty($this->options['player_width']) && !empty($this->options['player_height'])) {
+      $options['height'] = $this->options['player_height'];
+    }
+    $options['autostart'] = $this->options['player_autostart'] ? 'TRUE' : 'FALSE';
 
     try {
       $options['fatal'] = TRUE;


### PR DESCRIPTION
If an request is made with width and not height, the backend calculates
height on the basis of the aspect ratio of the file. So we allow to send
only width.
